### PR TITLE
Remove info logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+resilient-jersey-wrapper.iml

--- a/src/main/java/com/ft/jerseyhttpwrapper/AttemptLogger.java
+++ b/src/main/java/com/ft/jerseyhttpwrapper/AttemptLogger.java
@@ -33,8 +33,10 @@ public class AttemptLogger {
         long timeTakenMillis = (endTime - startMillis);
 
         LOGGER.debug("[ATTEMPT FINISHED] request_uri={}, request_entity={}", attemptUri, entity);
-        LOGGER.info("[ATTEMPT FINISHED] request_uri={}, outcome={}, time_ms={}", attemptUri, outcome, timeTakenMillis);
-
+        int status = Integer.parseInt(outcome);
+        if (status > 499 && status <= 599) {
+            LOGGER.error("[ATTEMPT FINISHED] request_uri={}, outcome={}, time_ms={}", attemptUri, outcome, timeTakenMillis);
+        }
     }
 
 }

--- a/src/main/java/com/ft/jerseyhttpwrapper/AttemptLogger.java
+++ b/src/main/java/com/ft/jerseyhttpwrapper/AttemptLogger.java
@@ -27,16 +27,24 @@ public class AttemptLogger {
     }
 
 
-    public void stop(String outcome) {
+    public void stop(int status) {
         long endTime = System.currentTimeMillis();
         attemptTimer.stop();
         long timeTakenMillis = (endTime - startMillis);
 
         LOGGER.debug("[ATTEMPT FINISHED] request_uri={}, request_entity={}", attemptUri, entity);
-        int status = Integer.parseInt(outcome);
+
+        String outcome = null;
         if (status > 499 && status <= 599) {
+            outcome = Integer.toString(status);
+        } else if (status == 0) {
+            outcome = "Exception";
+        }
+
+        if (outcome != null) {
             LOGGER.error("[ATTEMPT FINISHED] request_uri={}, outcome={}, time_ms={}", attemptUri, outcome, timeTakenMillis);
         }
     }
+
 
 }

--- a/src/main/java/com/ft/jerseyhttpwrapper/ResilientClient.java
+++ b/src/main/java/com/ft/jerseyhttpwrapper/ResilientClient.java
@@ -202,12 +202,10 @@ public class ResilientClient extends Client {
 
 
                     if(currentResponse!=null) {
-                        requestOutcome=Integer.toString(currentResponse.getStatus());
+                        attempt.stop(currentResponse.getStatus());
                     } else if(lastClientHandlerException!=null) {
-                        requestOutcome="Exception";
+                        attempt.stop(0);
                     }
-
-                    attempt.stop(requestOutcome);
                 }
             }
 

--- a/src/main/java/com/ft/jerseyhttpwrapper/ResilientClient.java
+++ b/src/main/java/com/ft/jerseyhttpwrapper/ResilientClient.java
@@ -144,8 +144,6 @@ public class ResilientClient extends Client {
                 clonedRequest.getHeaders().putSingle("User-Agent", userAgentSupplier.get());
                 
                 maybePropagateTransactionId(clonedRequest);
-                
-                String requestOutcome = "unknown";
 
                 AttemptLogger attempt = attemptLoggerFactory.startTimers(attemptUri, clonedRequest);
 
@@ -214,7 +212,7 @@ public class ResilientClient extends Client {
             attemptCounts.update(attemptCount);
 
             String outcome = "unknown";
-            int status = HttpStatus.SC_OK;
+            int status = 0;
             if(lastResponse!=null) {
                 status = lastResponse.getStatus();
                 outcome = Integer.toString(status);
@@ -222,9 +220,8 @@ public class ResilientClient extends Client {
                 outcome="Exception";
             }
 
-            String finishedMessage = String.format("[REQUEST FINISHED] short_name=%s, outcome=%s, total_attempts=%d, failed_attempts=%d", shortName, outcome, attemptCount, failedAttemptCount);
-
-            if(attemptCount==0 || (status > 399 && status <= 499)) {
+            if(attemptCount == 0 || (status > 499 && status <= 599)) {
+                String finishedMessage = String.format("[REQUEST FINISHED] short_name=%s, outcome=%s, total_attempts=%d, failed_attempts=%d", shortName, outcome, attemptCount, failedAttemptCount);
                 LOGGER.error(finishedMessage);
             }
         }

--- a/src/test/java/com/ft/jerseyhttpwrapper/continuation/ExponentialBackoffWithDNSStrategyClientTest.java
+++ b/src/test/java/com/ft/jerseyhttpwrapper/continuation/ExponentialBackoffWithDNSStrategyClientTest.java
@@ -87,46 +87,46 @@ public class ExponentialBackoffWithDNSStrategyClientTest {
         assertThat(client, notNullValue());
     }
 
-    @Test
-    public void shouldHitEachEndpointInTurnAndWrapAround() throws InterruptedException, ExecutionException {
-
-        givenThreeNodesAreLookedUp();
-
-        Future<Exception> expectedException = asynchronously(new Callable<Exception>() {
-            @Override
-            public Exception call() {
-                try {
-                client.resource(urlOf(instanceRule1)).get(String.class);
-                } catch(Exception e) {
-                    return e;
-                }
-                return null;
-            }
-        });
-
-        Thread.sleep(1000);
-
-        instanceRule1.verify(1, getRequestedFor(urlEqualTo("/path")));
-        instanceRule2.verify(0, getRequestedFor(urlEqualTo("/path")));
-
-        Thread.sleep(1000);
-
-        instanceRule2.verify(1, getRequestedFor(urlEqualTo("/path")));
-        instanceRule3.verify(0, getRequestedFor(urlEqualTo("/path")));
-
-        Thread.sleep(2000);
-
-        instanceRule3.verify(1, getRequestedFor(urlEqualTo("/path")));
-        instanceRule1.verify(1, getRequestedFor(urlEqualTo("/path")));
-
-        Thread.sleep(4000);
-
-        instanceRule1.verify(2, getRequestedFor(urlEqualTo("/path")));
-
-
-        assertThat(expectedException.get(),instanceOf(UniformInterfaceException.class));
-
-    }
+//    @Test
+//    public void shouldHitEachEndpointInTurnAndWrapAround() throws InterruptedException, ExecutionException {
+//
+//        givenThreeNodesAreLookedUp();
+//
+//        Future<Exception> expectedException = asynchronously(new Callable<Exception>() {
+//            @Override
+//            public Exception call() {
+//                try {
+//                client.resource(urlOf(instanceRule1)).get(String.class);
+//                } catch(Exception e) {
+//                    return e;
+//                }
+//                return null;
+//            }
+//        });
+//
+//        Thread.sleep(1000);
+//
+//        instanceRule1.verify(1, getRequestedFor(urlEqualTo("/path")));
+//        instanceRule2.verify(0, getRequestedFor(urlEqualTo("/path")));
+//
+//        Thread.sleep(1000);
+//
+//        instanceRule2.verify(1, getRequestedFor(urlEqualTo("/path")));
+//        instanceRule3.verify(0, getRequestedFor(urlEqualTo("/path")));
+//
+//        Thread.sleep(2000);
+//
+//        instanceRule3.verify(1, getRequestedFor(urlEqualTo("/path")));
+//        instanceRule1.verify(1, getRequestedFor(urlEqualTo("/path")));
+//
+//        Thread.sleep(4000);
+//
+//        instanceRule1.verify(2, getRequestedFor(urlEqualTo("/path")));
+//
+//
+//        assertThat(expectedException.get(),instanceOf(UniformInterfaceException.class));
+//
+//    }
 
     private URI urlOf(WireMockClassRule instanceRule1) {
         return UriBuilder.fromPath("/path")

--- a/src/test/java/com/ft/jerseyhttpwrapper/continuation/ExponentialBackoffWithDNSStrategyClientTest.java
+++ b/src/test/java/com/ft/jerseyhttpwrapper/continuation/ExponentialBackoffWithDNSStrategyClientTest.java
@@ -87,46 +87,46 @@ public class ExponentialBackoffWithDNSStrategyClientTest {
         assertThat(client, notNullValue());
     }
 
-//    @Test
-//    public void shouldHitEachEndpointInTurnAndWrapAround() throws InterruptedException, ExecutionException {
-//
-//        givenThreeNodesAreLookedUp();
-//
-//        Future<Exception> expectedException = asynchronously(new Callable<Exception>() {
-//            @Override
-//            public Exception call() {
-//                try {
-//                client.resource(urlOf(instanceRule1)).get(String.class);
-//                } catch(Exception e) {
-//                    return e;
-//                }
-//                return null;
-//            }
-//        });
-//
-//        Thread.sleep(1000);
-//
-//        instanceRule1.verify(1, getRequestedFor(urlEqualTo("/path")));
-//        instanceRule2.verify(0, getRequestedFor(urlEqualTo("/path")));
-//
-//        Thread.sleep(1000);
-//
-//        instanceRule2.verify(1, getRequestedFor(urlEqualTo("/path")));
-//        instanceRule3.verify(0, getRequestedFor(urlEqualTo("/path")));
-//
-//        Thread.sleep(2000);
-//
-//        instanceRule3.verify(1, getRequestedFor(urlEqualTo("/path")));
-//        instanceRule1.verify(1, getRequestedFor(urlEqualTo("/path")));
-//
-//        Thread.sleep(4000);
-//
-//        instanceRule1.verify(2, getRequestedFor(urlEqualTo("/path")));
-//
-//
-//        assertThat(expectedException.get(),instanceOf(UniformInterfaceException.class));
-//
-//    }
+    @Test
+    public void shouldHitEachEndpointInTurnAndWrapAround() throws InterruptedException, ExecutionException {
+
+        givenThreeNodesAreLookedUp();
+
+        Future<Exception> expectedException = asynchronously(new Callable<Exception>() {
+            @Override
+            public Exception call() {
+                try {
+                client.resource(urlOf(instanceRule1)).get(String.class);
+                } catch(Exception e) {
+                    return e;
+                }
+                return null;
+            }
+        });
+
+        Thread.sleep(1000);
+
+        instanceRule1.verify(1, getRequestedFor(urlEqualTo("/path")));
+        instanceRule2.verify(0, getRequestedFor(urlEqualTo("/path")));
+
+        Thread.sleep(1000);
+
+        instanceRule2.verify(1, getRequestedFor(urlEqualTo("/path")));
+        instanceRule3.verify(0, getRequestedFor(urlEqualTo("/path")));
+
+        Thread.sleep(2000);
+
+        instanceRule3.verify(1, getRequestedFor(urlEqualTo("/path")));
+        instanceRule1.verify(1, getRequestedFor(urlEqualTo("/path")));
+
+        Thread.sleep(4000);
+
+        instanceRule1.verify(2, getRequestedFor(urlEqualTo("/path")));
+
+
+        assertThat(expectedException.get(),instanceOf(UniformInterfaceException.class));
+
+    }
 
     private URI urlOf(WireMockClassRule instanceRule1) {
         return UriBuilder.fromPath("/path")


### PR DESCRIPTION
The client should log only failed requests, in order to reduce the number of log entries.