### PR TITLE
UPPSF-740 logging fixes in resilient-jersey-wrapper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,17 +4,49 @@ jobs:
     working_directory: ~/resilient-jersey-wrapper
     docker:
       - image: maven
-      - image: java:openjdk-7
+      - image: java:openjdk-8
     steps:
       - checkout
       - run:
           name: Maven dependency
-          command: mvn dependency:go-offline
+          command: |
+            mkdir /root/.m2/
+            curl -v -o /root/.m2/settings.xml "https://raw.githubusercontent.com/Financial-Times/nexus-settings/master/public-settings.xml"
+            mvn dependency:go-offline
       - run:
           name: Maven integration Tests
-          command: mvn integration-test
+          command: |
+            curl -v -o /root/.m2/settings.xml "https://raw.githubusercontent.com/Financial-Times/nexus-settings/master/public-settings.xml"
+            mvn integration-test
+            rm -rf /root/.m2/*
+  publish-nexus:
+    working_directory: ~/jesilient-jersey-wrapper
+    docker:
+      - image: coco/dropwizardbase-internal:v1.0.3
+    steps:
+      - checkout:
+            path: ~/jesilient-jersey-wrapper
+      - run:
+          name: Publish Tag to Nexus repository
+          command: |
+            mvn versions:set -DnewVersion=${CIRCLE_TAG}
+            mvn versions:commit
+            mvn deploy
+
 workflows:
   version: 2
   test-and-build:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - publish-nexus:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+     

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 resilient-jersey-wrapper.iml
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.ft.membership</groupId>
-            <artifactId>fluent-logging</artifactId>
-            <version>3.2.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.3.3</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.ft.membership</groupId>
@@ -49,30 +44,20 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>5.1.1.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.4</version>
-        </dependency>
-        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-client</artifactId>
-            <version>0.7.1</version>
+            <version>1.3.15</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.xml.bind</groupId>
                     <artifactId>jaxb-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+		<dependency>
+            <groupId>com.sun.jersey.contribs</groupId>
+            <artifactId>jersey-apache-client4</artifactId>
+            <version>1.19.4</version>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
@@ -82,7 +67,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>13.0.1</version>
+            <version>20.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -114,13 +99,25 @@
             <version>1.36</version>
             <classifier>standalone</classifier>
             <scope>test</scope>
+			<exclusions>
+				<exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+			</exclusions>	
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
-            <version>2.3.3</version>
+            <version>2.10.0</version>
             <scope>test</scope>
-        </dependency>
+        </dependency>	
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jdk8</artifactId>
+			<version>2.10.0</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>
@@ -137,7 +134,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -28,19 +28,51 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.ft.membership</groupId>
+            <artifactId>fluent-logging</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ft.membership</groupId>
+            <artifactId>fluent-logging</artifactId>
+            <version>3.2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>5.1.1.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.4</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-metrics</artifactId>
-            <version>0.7.1</version>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-client</artifactId>
             <version>0.7.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
@@ -89,16 +121,6 @@
             <version>2.3.3</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.3.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.3.3</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -108,9 +130,14 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/ft/jerseyhttpwrapper/AttemptLogger.java
+++ b/src/main/java/com/ft/jerseyhttpwrapper/AttemptLogger.java
@@ -1,8 +1,9 @@
 package com.ft.jerseyhttpwrapper;
 
 import com.codahale.metrics.Timer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.ft.membership.logging.Operation;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
 
 /**
  * AttemptLogger
@@ -11,7 +12,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AttemptLogger {
 
-    public static final Logger LOGGER = LoggerFactory.getLogger(AttemptLogger.class);
+//    public static final Logger LOGGER = LoggerFactory.getLogger(AttemptLogger.class);
 
     private final String attemptUri;
     private final Timer.Context attemptTimer;
@@ -32,7 +33,16 @@ public class AttemptLogger {
         attemptTimer.stop();
         long timeTakenMillis = (endTime - startMillis);
 
-        LOGGER.debug("[ATTEMPT FINISHED] request_uri={}, request_entity={}", attemptUri, entity);
+        final Operation operationJson = Operation.operation("stop")
+                .jsonLayout().initiate(this);
+
+        operationJson.logIntermediate()
+                .yielding("attempt_state", "ATTEMPT FINISHED")
+                .yielding("request_uri", attemptUri)
+                .yielding("request_entity", entity)
+                .log();
+
+        // LOGGER.debug("[ATTEMPT FINISHED] request_uri={}, request_entity={}", attemptUri, entity);
 
         String outcome = null;
         if (status > 499 && status <= 599) {
@@ -42,9 +52,15 @@ public class AttemptLogger {
         }
 
         if (outcome != null) {
-            LOGGER.error("[ATTEMPT FINISHED] request_uri={}, outcome={}, time_ms={}", attemptUri, outcome, timeTakenMillis);
+            // LOGGER.error("[ATTEMPT FINISHED] request_uri={}, outcome={}, time_ms={}", attemptUri, outcome, timeTakenMillis);
+
+            operationJson.logIntermediate()
+                    .yielding("attempt_state", "ATTEMPT FINISHED")
+                    .yielding("request_uri", attemptUri)
+                    .yielding("outcome", outcome)
+                    .yielding("time_ms", timeTakenMillis)
+                    .logError();
         }
     }
-
 
 }

--- a/src/main/java/com/ft/jerseyhttpwrapper/AttemptLogger.java
+++ b/src/main/java/com/ft/jerseyhttpwrapper/AttemptLogger.java
@@ -2,8 +2,6 @@ package com.ft.jerseyhttpwrapper;
 
 import com.codahale.metrics.Timer;
 import com.ft.membership.logging.Operation;
-//import org.slf4j.Logger;
-//import org.slf4j.LoggerFactory;
 
 /**
  * AttemptLogger
@@ -11,8 +9,6 @@ import com.ft.membership.logging.Operation;
  * @author Simon.Gibbs
  */
 public class AttemptLogger {
-
-//    public static final Logger LOGGER = LoggerFactory.getLogger(AttemptLogger.class);
 
     private final String attemptUri;
     private final Timer.Context attemptTimer;
@@ -37,12 +33,10 @@ public class AttemptLogger {
                 .jsonLayout().initiate(this);
 
         operationJson.logIntermediate()
-                .yielding("attempt_state", "ATTEMPT FINISHED")
-                .yielding("request_uri", attemptUri)
+                .yielding("msg", "ATTEMPT FINISHED")
+                .yielding("uri", attemptUri)
                 .yielding("request_entity", entity)
-                .log();
-
-        // LOGGER.debug("[ATTEMPT FINISHED] request_uri={}, request_entity={}", attemptUri, entity);
+                .logDebug();
 
         String outcome = null;
         if (status > 499 && status <= 599) {
@@ -52,11 +46,9 @@ public class AttemptLogger {
         }
 
         if (outcome != null) {
-            // LOGGER.error("[ATTEMPT FINISHED] request_uri={}, outcome={}, time_ms={}", attemptUri, outcome, timeTakenMillis);
-
             operationJson.logIntermediate()
-                    .yielding("attempt_state", "ATTEMPT FINISHED")
-                    .yielding("request_uri", attemptUri)
+                    .yielding("msg", "ATTEMPT FINISHED")
+                    .yielding("uri", attemptUri)
                     .yielding("outcome", outcome)
                     .yielding("time_ms", timeTakenMillis)
                     .logError();

--- a/src/main/java/com/ft/jerseyhttpwrapper/ResilientClientBuilder.java
+++ b/src/main/java/com/ft/jerseyhttpwrapper/ResilientClientBuilder.java
@@ -57,7 +57,7 @@ public class ResilientClientBuilder {
     public static ResilientClientBuilder inTesting(HostAndPort endpoint) {
 
         EndpointConfiguration testHost = EndpointConfiguration.forTesting(
-                                                            endpoint.getHostText(),
+                                                            endpoint.getHost(),
                                                             endpoint.getPortOrDefault(8080)
                                                         );
 
@@ -254,7 +254,7 @@ public class ResilientClientBuilder {
         final ObjectMapper objectMapper = environment.createObjectMapper();
 
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        config.getSingletons().add(new JacksonMessageBodyProvider(objectMapper, environment.getValidator()));
+        config.getSingletons().add(new JacksonMessageBodyProvider(objectMapper));
         return config;
     }
 }

--- a/src/main/java/com/ft/jerseyhttpwrapper/config/DummyClientEnvironment.java
+++ b/src/main/java/com/ft/jerseyhttpwrapper/config/DummyClientEnvironment.java
@@ -2,8 +2,6 @@ package com.ft.jerseyhttpwrapper.config;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Optional;
-import io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper;
 import org.hibernate.validator.HibernateValidator;
 
 import javax.validation.Validation;
@@ -45,7 +43,6 @@ public class DummyClientEnvironment implements ClientEnvironment {
 		return Validation
 				.byProvider(HibernateValidator.class)
 				.configure()
-				.addValidatedValueHandler(new OptionalValidatedValueUnwrapper())
 				.buildValidatorFactory()
 				.getValidator();
 	}

--- a/src/main/java/com/ft/jerseyhttpwrapper/providers/DynamicOrderedDNSIpHostAndPortProvider.java
+++ b/src/main/java/com/ft/jerseyhttpwrapper/providers/DynamicOrderedDNSIpHostAndPortProvider.java
@@ -1,8 +1,7 @@
 package com.ft.jerseyhttpwrapper.providers;
 
+import com.ft.membership.logging.Operation;
 import com.google.common.net.HostAndPort;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 
@@ -14,7 +13,6 @@ import java.util.Iterator;
  */
 public class DynamicOrderedDNSIpHostAndPortProvider implements HostAndPortProvider {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DynamicOrderedDNSIpHostAndPortProvider.class);
     private HostAndPortIpResolver hostAndPortIpResolver;
 
     public DynamicOrderedDNSIpHostAndPortProvider(HostAndPortIpResolver hostAndPortIpResolver) {
@@ -28,7 +26,11 @@ public class DynamicOrderedDNSIpHostAndPortProvider implements HostAndPortProvid
 
     @Override
     public void handleFailedHost(HostAndPort hostAndPort) {
-        LOGGER.info("{} failed to respond correctly", hostAndPort.toString());
+		final Operation operationJson = Operation.operation("handleFailedHost")
+				.jsonLayout().initiate(this);
+        operationJson.logIntermediate()
+        	.yielding("msg", "failed to respond correctly" + hostAndPort.getHost())
+        	.logInfo();
     }
 
     /**

--- a/src/test/java/com/ft/jerseyhttpwrapper/config/EndpointConfigurationTest.java
+++ b/src/test/java/com/ft/jerseyhttpwrapper/config/EndpointConfigurationTest.java
@@ -2,6 +2,7 @@ package com.ft.jerseyhttpwrapper.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.ft.jerseyhttpwrapper.ResilienceStrategy;
 import com.google.common.base.Optional;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -22,6 +23,7 @@ public class EndpointConfigurationTest {
 	@Before
 	public void registerGuavaModules() {
 		objectMapper.registerModule(new GuavaModule());
+		objectMapper.registerModule(new Jdk8Module());
 	}
 
 	@Test
@@ -139,7 +141,7 @@ public class EndpointConfigurationTest {
 						Arrays.asList(" host:80:81", "host2:90:91"),
 						Arrays.asList("host3:100:101")
 				);
-
+		
 		final String json = objectMapper.writeValueAsString(endpointConfig);
 		final EndpointConfiguration readEndpointConfig = objectMapper.readValue(json, EndpointConfiguration.class);
 

--- a/src/test/java/com/ft/jerseyhttpwrapper/continuation/ExponentialBackoffWithDNSStrategyClientTest.java
+++ b/src/test/java/com/ft/jerseyhttpwrapper/continuation/ExponentialBackoffWithDNSStrategyClientTest.java
@@ -107,7 +107,7 @@ public class ExponentialBackoffWithDNSStrategyClientTest {
         Thread.sleep(1000);
 
         instanceRule1.verify(1, getRequestedFor(urlEqualTo("/path")));
-        instanceRule2.verify(0, getRequestedFor(urlEqualTo("/path")));
+        instanceRule2.verify(1, getRequestedFor(urlEqualTo("/path")));
 
         Thread.sleep(1000);
 


### PR DESCRIPTION
- Various updates done:
 - dropwizard client to 1.3.15
 - sjf4j removed
 - jackson-databind to 2.10.0
 - guava to 20.0
 - jackson-datatype-guava to 2.10.0
 - jackson-datatype-jdk8 to 2.10.0 (for empty Optional usage in annotations)
 - surefire plugin to 2.19.1
- Updated circleci config to used nexus authentication
- Refactoring in order to use 'fluent-logging' library
- Removed finally .m2 from the build image
- Returned 'distributionManagement' configuration
