### PR TITLE
Feature/cyber essentials2024

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,16 @@
 
     <groupId>com.ft.resilient-jersey-wrapper</groupId>
     <artifactId>resilient-jersey-wrapper</artifactId>
-    <version>0.3-SNAPSHOT</version>
+    <version>0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>FT Resilient Jersey Client wrapper</name>
 
     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     </properties>
 
     <distributionManagement>
@@ -66,10 +69,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client -->
         <dependency>
-            <groupId>com.sun.jersey</groupId>
+            <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>1.18.1</version>
+            <version>2.42</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -132,16 +136,30 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
+                <configuration>
+                    <argLine>
+                        -Dsun.net.http.allowRestrictedHeaders=true
+                        <!-- Uncomment the following arguments
+                             and change them to start with double dash without space
+                             to run with newer than Java11 version locally-->
+                        <!--            - -add-opens java.base/java.lang=ALL-UNNAMED-->
+                        <!--            - -add-opens java.base/java.util=ALL-UNNAMED-->
+                        <!--            - -add-opens java.base/java.lang.reflect=ALL-UNNAMED-->
+                        <!--            - -add-opens java.base/java.text=ALL-UNNAMED-->
+                        <!--            - -add-opens java.desktop/java.awt.font=ALL-UNNAMED-->
+                    </argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/com/ft/jerseyhttpwrapper/ResilientClientTest.java
+++ b/src/test/java/com/ft/jerseyhttpwrapper/ResilientClientTest.java
@@ -126,7 +126,7 @@ public class ResilientClientTest {
         aResponse()
             .withStatus(200)
             .withHeader(CONTENT_TYPE, "text/plain")
-            .withFixedDelay(501)
+            .withFixedDelay(505)
             .withBody("Hello world"));
 
     resource(builder.build()).get(ClientResponse.class);

--- a/src/test/java/com/ft/jerseyhttpwrapper/continuation/ExponentialBackoffContinuationSessionTest.java
+++ b/src/test/java/com/ft/jerseyhttpwrapper/continuation/ExponentialBackoffContinuationSessionTest.java
@@ -39,7 +39,7 @@ public class ExponentialBackoffContinuationSessionTest {
 
   private Runnable sessionLoadGenerator(final ContinuationSession session) {
     return new Runnable() {
-      @Override
+
       public void run() {
         // this will run until interrupted
         while (session.shouldContinue()) {
@@ -95,14 +95,14 @@ public class ExponentialBackoffContinuationSessionTest {
 
     Thread threadUnderTest = new Thread(sessionLoadGenerator(session));
 
-    // interrupt the the thread almost immediately
+    // interrupt the thread almost immediately
     threadUnderTest.start();
 
     sleepFor(5);
     assertThat(hostsReturned, is(1));
     sleepFor(100);
     assertThat(hostsReturned, is(2));
-    sleepFor(200);
+    sleepFor(210);
     assertThat(hostsReturned, is(3));
     sleepFor(400);
     assertThat(hostsReturned, is(4));


### PR DESCRIPTION
# Description

Updated JDK version for the build

## What

Updated JDK version from 7 to 8 as Java7 is not supported anymore.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-5238 

## Anything, in particular, you'd like to highlight to reviewers

Changed java build version from 1.7 to 1.8. One of the tests were unstable so adjusted the values to wait to pass consistently. 
Used image was already with Java 11 - maven:3.6-jdk-11

_Would appreciate a second pair of eyes_  


## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
