### PR TITLE
CyberEssentials2024 revert to Jersey1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client -->
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
+            <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.42</version>
+            <version>1.19.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
# Description

## What

Revert Jersey to Jersey1 as Projects are not ready for two.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-5238

## Anything, in particular, you'd like to highlight to reviewers

Projects are build for Jersey1 so we need Jersey one client.

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
